### PR TITLE
User sees word error

### DIFF
--- a/WordRot/ContentView.swift
+++ b/WordRot/ContentView.swift
@@ -7,11 +7,20 @@
 
 import SwiftUI
 
+let validWords = [
+    "foo",
+    "bar"
+]
+
 struct ContentView: View {
     @State private var word: String = ""
+    @State private var wordError = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
+            if wordError {
+              Text("Word Not Found")
+            }
             TextField("", text:$word)
                 .textFieldStyle(.roundedBorder)
             Button(action: playWord) {
@@ -24,7 +33,11 @@ struct ContentView: View {
     }
     
     func playWord() {
-        word = ""
+        if validWords.contains(word.lowercased()) {
+            word = ""
+        } else {
+            wordError = true
+        }
     }
 }
 


### PR DESCRIPTION
Not very sophisticated but I've got the skeleton:
![Simulator Screen Shot - iPod touch (7th generation) - 2022-02-05 at 10 13 37](https://user-images.githubusercontent.com/79799/152649500-51c002bb-40fc-4df8-804d-65864ecfe3a0.png)

