### PR TITLE
User sees played words

### DIFF
--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		FC036FCB27C59F2100325826 /* GameStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC036FCA27C59F2100325826 /* GameStore.swift */; };
+		FC036FCD27C5DAF100325826 /* WordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC036FCC27C5DAF100325826 /* WordsView.swift */; };
 		FC09A6FD27AF4BDB00715D3E /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC09A6FC27AF4BDB00715D3E /* TitleView.swift */; };
 		FC09A6FF27AF811600715D3E /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC09A6FE27AF811600715D3E /* Game.swift */; };
 		FC8F74AF27A4831400779157 /* WordRotApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8F74AE27A4831400779157 /* WordRotApp.swift */; };
@@ -38,6 +39,7 @@
 
 /* Begin PBXFileReference section */
 		FC036FCA27C59F2100325826 /* GameStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameStore.swift; sourceTree = "<group>"; };
+		FC036FCC27C5DAF100325826 /* WordsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordsView.swift; sourceTree = "<group>"; };
 		FC09A6FC27AF4BDB00715D3E /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		FC09A6FE27AF811600715D3E /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
 		FC8F74AB27A4831400779157 /* WordRot.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordRot.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -82,6 +84,7 @@
 			children = (
 				FC8F74B027A4831400779157 /* GameView.swift */,
 				FC09A6FC27AF4BDB00715D3E /* TitleView.swift */,
+				FC036FCC27C5DAF100325826 /* WordsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -284,6 +287,7 @@
 			files = (
 				FC8F74B127A4831400779157 /* GameView.swift in Sources */,
 				FC8F74AF27A4831400779157 /* WordRotApp.swift in Sources */,
+				FC036FCD27C5DAF100325826 /* WordsView.swift in Sources */,
 				FC09A6FD27AF4BDB00715D3E /* TitleView.swift in Sources */,
 				FC036FCB27C59F2100325826 /* GameStore.swift in Sources */,
 				FC09A6FF27AF811600715D3E /* Game.swift in Sources */,

--- a/WordRot/Views/GameView.swift
+++ b/WordRot/Views/GameView.swift
@@ -10,6 +10,11 @@ struct GameView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             Text("score: \(game.score)")
+            
+            NavigationLink("words", destination: WordsView(game: game))
+                .buttonStyle(.bordered)
+                .foregroundColor(.black)
+            
             TextField("", text: $word)
                 .textFieldStyle(.roundedBorder)
             

--- a/WordRot/Views/WordsView.swift
+++ b/WordRot/Views/WordsView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct WordsView: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    @ObservedObject var game: Game
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 30) {
+            HStack() {
+                Text("Played Words")
+                Spacer()
+                Button("done", action: handleDonePress)
+                    .buttonStyle(.bordered)
+                    .foregroundColor(.black)
+            }
+            
+            ForEach(game.playedWords, id: \.self) { word in
+                Text(word)
+            }
+            
+            Spacer()
+        }
+        .padding(30)
+        .navigationBarBackButtonHidden(true)
+    }
+    
+    func handleDonePress() {
+        dismiss()
+    }
+}
+
+struct WordsView_Previews: PreviewProvider {
+    static var previews: some View {
+        let game = Game()
+        game.playedWords = ["Foo", "Bar"]
+        return WordsView(game: game)
+    }
+}


### PR DESCRIPTION
This PR adds a view that lists the played words, looks like this:

<img width="564" alt="Screen Shot 2022-02-22 at 9 11 35 PM" src="https://user-images.githubusercontent.com/79799/155255871-e2af8fab-e310-4067-9126-06c8220cfd1f.png">

Case closed.