### PR TITLE
Begin styling colors and fonts

### DIFF
--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		FC84210D27CADE620035E151 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210C27CADE620035E151 /* Color.swift */; };
 		FC84210F27CADE9D0035E151 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210E27CADE9D0035E151 /* Font.swift */; };
 		FC84211127CAE07D0035E151 /* RottenButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84211027CAE07D0035E151 /* RottenButton.swift */; };
+		FC84211327CAE2550035E151 /* RottenLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84211227CAE2550035E151 /* RottenLink.swift */; };
 		FC8F74AF27A4831400779157 /* WordRotApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8F74AE27A4831400779157 /* WordRotApp.swift */; };
 		FC8F74B127A4831400779157 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8F74B027A4831400779157 /* GameView.swift */; };
 		FC8F74B327A4831600779157 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FC8F74B227A4831600779157 /* Assets.xcassets */; };
@@ -53,6 +54,7 @@
 		FC84210C27CADE620035E151 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		FC84210E27CADE9D0035E151 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 		FC84211027CAE07D0035E151 /* RottenButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RottenButton.swift; sourceTree = "<group>"; };
+		FC84211227CAE2550035E151 /* RottenLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RottenLink.swift; sourceTree = "<group>"; };
 		FC8F74AB27A4831400779157 /* WordRot.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordRot.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC8F74AE27A4831400779157 /* WordRotApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordRotApp.swift; sourceTree = "<group>"; };
 		FC8F74B027A4831400779157 /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
@@ -98,6 +100,7 @@
 				FC09A6FC27AF4BDB00715D3E /* TitleView.swift */,
 				FC036FCC27C5DAF100325826 /* WordsView.swift */,
 				FC84211027CAE07D0035E151 /* RottenButton.swift */,
+				FC84211227CAE2550035E151 /* RottenLink.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -320,6 +323,7 @@
 				FC8F74B127A4831400779157 /* GameView.swift in Sources */,
 				FC8F74AF27A4831400779157 /* WordRotApp.swift in Sources */,
 				FC036FCD27C5DAF100325826 /* WordsView.swift in Sources */,
+				FC84211327CAE2550035E151 /* RottenLink.swift in Sources */,
 				FC09A6FD27AF4BDB00715D3E /* TitleView.swift in Sources */,
 				FC036FD427C5F2A500325826 /* Dictionary.swift in Sources */,
 				FC84210F27CADE9D0035E151 /* Font.swift in Sources */,

--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		FC11EB7C27C69AAE00346270 /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = FC11EB7B27C69AAE00346270 /* SQLite */; };
 		FC84210D27CADE620035E151 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210C27CADE620035E151 /* Color.swift */; };
 		FC84210F27CADE9D0035E151 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210E27CADE9D0035E151 /* Font.swift */; };
+		FC84211127CAE07D0035E151 /* RottenButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84211027CAE07D0035E151 /* RottenButton.swift */; };
 		FC8F74AF27A4831400779157 /* WordRotApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8F74AE27A4831400779157 /* WordRotApp.swift */; };
 		FC8F74B127A4831400779157 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8F74B027A4831400779157 /* GameView.swift */; };
 		FC8F74B327A4831600779157 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FC8F74B227A4831600779157 /* Assets.xcassets */; };
@@ -51,6 +52,7 @@
 		FC09A6FE27AF811600715D3E /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
 		FC84210C27CADE620035E151 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		FC84210E27CADE9D0035E151 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
+		FC84211027CAE07D0035E151 /* RottenButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RottenButton.swift; sourceTree = "<group>"; };
 		FC8F74AB27A4831400779157 /* WordRot.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordRot.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC8F74AE27A4831400779157 /* WordRotApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordRotApp.swift; sourceTree = "<group>"; };
 		FC8F74B027A4831400779157 /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				FC8F74B027A4831400779157 /* GameView.swift */,
 				FC09A6FC27AF4BDB00715D3E /* TitleView.swift */,
 				FC036FCC27C5DAF100325826 /* WordsView.swift */,
+				FC84211027CAE07D0035E151 /* RottenButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -321,6 +324,7 @@
 				FC036FD427C5F2A500325826 /* Dictionary.swift in Sources */,
 				FC84210F27CADE9D0035E151 /* Font.swift in Sources */,
 				FC84210D27CADE620035E151 /* Color.swift in Sources */,
+				FC84211127CAE07D0035E151 /* RottenButton.swift in Sources */,
 				FC036FCB27C59F2100325826 /* GameStore.swift in Sources */,
 				FC09A6FF27AF811600715D3E /* Game.swift in Sources */,
 			);

--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		FC09A6FD27AF4BDB00715D3E /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC09A6FC27AF4BDB00715D3E /* TitleView.swift */; };
 		FC09A6FF27AF811600715D3E /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC09A6FE27AF811600715D3E /* Game.swift */; };
 		FC11EB7C27C69AAE00346270 /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = FC11EB7B27C69AAE00346270 /* SQLite */; };
+		FC84210D27CADE620035E151 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210C27CADE620035E151 /* Color.swift */; };
+		FC84210F27CADE9D0035E151 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210E27CADE9D0035E151 /* Font.swift */; };
 		FC8F74AF27A4831400779157 /* WordRotApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8F74AE27A4831400779157 /* WordRotApp.swift */; };
 		FC8F74B127A4831400779157 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC8F74B027A4831400779157 /* GameView.swift */; };
 		FC8F74B327A4831600779157 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FC8F74B227A4831600779157 /* Assets.xcassets */; };
@@ -47,6 +49,8 @@
 		FC036FD627C5F67200325826 /* words.sqlite3 */ = {isa = PBXFileReference; lastKnownFileType = file; path = words.sqlite3; sourceTree = "<group>"; };
 		FC09A6FC27AF4BDB00715D3E /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
 		FC09A6FE27AF811600715D3E /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
+		FC84210C27CADE620035E151 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		FC84210E27CADE9D0035E151 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 		FC8F74AB27A4831400779157 /* WordRot.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordRot.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC8F74AE27A4831400779157 /* WordRotApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordRotApp.swift; sourceTree = "<group>"; };
 		FC8F74B027A4831400779157 /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
@@ -105,6 +109,15 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		FC84210B27CADE540035E151 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				FC84210C27CADE620035E151 /* Color.swift */,
+				FC84210E27CADE9D0035E151 /* Font.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		FC8F74A227A4831400779157 = {
 			isa = PBXGroup;
 			children = (
@@ -128,6 +141,7 @@
 		FC8F74AD27A4831400779157 /* WordRot */ = {
 			isa = PBXGroup;
 			children = (
+				FC84210B27CADE540035E151 /* Extensions */,
 				FC036FC927C59ECD00325826 /* Models */,
 				FC036FC827C59EB300325826 /* Views */,
 				FC8F74AE27A4831400779157 /* WordRotApp.swift */,
@@ -305,6 +319,8 @@
 				FC036FCD27C5DAF100325826 /* WordsView.swift in Sources */,
 				FC09A6FD27AF4BDB00715D3E /* TitleView.swift in Sources */,
 				FC036FD427C5F2A500325826 /* Dictionary.swift in Sources */,
+				FC84210F27CADE9D0035E151 /* Font.swift in Sources */,
+				FC84210D27CADE620035E151 /* Color.swift in Sources */,
 				FC036FCB27C59F2100325826 /* GameStore.swift in Sources */,
 				FC09A6FF27AF811600715D3E /* Game.swift in Sources */,
 			);

--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -97,10 +97,10 @@
 			isa = PBXGroup;
 			children = (
 				FC8F74B027A4831400779157 /* GameView.swift */,
-				FC09A6FC27AF4BDB00715D3E /* TitleView.swift */,
-				FC036FCC27C5DAF100325826 /* WordsView.swift */,
 				FC84211027CAE07D0035E151 /* RottenButton.swift */,
 				FC84211227CAE2550035E151 /* RottenLink.swift */,
+				FC09A6FC27AF4BDB00715D3E /* TitleView.swift */,
+				FC036FCC27C5DAF100325826 /* WordsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";

--- a/WordRot.xcodeproj/xcuserdata/jon.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WordRot.xcodeproj/xcuserdata/jon.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -28,7 +28,7 @@
 		<key>WordRot.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/WordRot/Extensions/Color.swift
+++ b/WordRot/Extensions/Color.swift
@@ -1,0 +1,5 @@
+import SwiftUI
+
+extension Color {
+    static let complete = Color(red: 37/255, green: 99/255, blue: 39/255)
+}

--- a/WordRot/Extensions/Font.swift
+++ b/WordRot/Extensions/Font.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+let futuraFontName = "Futura-Medium"
+
+extension Font {
+    static func futura(_ size: CGFloat) -> Font {
+        return Font.custom(futuraFontName, size: size)
+    }
+}

--- a/WordRot/Views/GameView.swift
+++ b/WordRot/Views/GameView.swift
@@ -9,10 +9,20 @@ struct GameView: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
-            Text("score: \(game.score)")
-                .font(Font.futura(30))
-            
-            RottenLink("words", destination: WordsView(game: game))
+            HStack() {
+                RottenButton("quit", action: quitGame)
+                    .frame(width: 100, alignment: .leading)
+                
+                Spacer()
+                
+                Text(String(game.score))
+                    .font(Font.futura(60))
+                
+                Spacer()
+                
+                RottenLink("words", destination: WordsView(game: game))
+                    .frame(width: 100, alignment: .trailing)
+            }
             
             TextField("", text: $word)
                 .textFieldStyle(.roundedBorder)
@@ -20,13 +30,17 @@ struct GameView: View {
             HStack(spacing: 20) {
                 RottenButton("play", action: playWord)
                 
-                if let message = game.lastError {
-                    Text(message)
-                        .font(Font.futura(30))
-                }
+                Spacer()
+                
+                RottenButton("delete", action: deleteLetter)
             }
             
-            RottenButton("quit", action: quitGame)
+            if let message = game.lastError {
+                Text(message)
+                    .font(Font.futura(30))
+            }
+            
+            Spacer()
         }
         .padding(20)
         .navigationBarHidden(true)
@@ -38,6 +52,10 @@ struct GameView: View {
         if game.lastError == nil {
             word = ""
         }
+    }
+    
+    func deleteLetter() {
+        word.removeLast()
     }
     
     func quitGame() {

--- a/WordRot/Views/GameView.swift
+++ b/WordRot/Views/GameView.swift
@@ -10,31 +10,32 @@ struct GameView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
             Text("score: \(game.score)")
+                .font(Font.futura(30))
             
             NavigationLink("words", destination: WordsView(game: game))
                 .buttonStyle(.bordered)
-                .foregroundColor(.black)
+                .foregroundColor(Color.white)
+                .font(Font.futura(30))
             
             TextField("", text: $word)
                 .textFieldStyle(.roundedBorder)
             
             HStack(spacing: 20) {
-                Button(action: playWord) {
-                    Text("play")
-                }
-                .buttonStyle(.bordered)
-                .foregroundColor(.black)
+                Button("play", action: playWord)
+                    .buttonStyle(.bordered)
+                    .foregroundColor(Color.white)
+                    .font(Font.futura(30))
                 
                 if let message = game.lastError {
-                  Text(message)
+                    Text(message)
+                        .font(Font.futura(30))
                 }
             }
             
-            Button(action: quitGame) {
-                Text("quit")
-            }
-            .buttonStyle(.bordered)
-            .foregroundColor(.black)
+            Button("quit", action: quitGame)
+                .buttonStyle(.bordered)
+                .font(Font.futura(30))
+                .foregroundColor(Color.white)
         }
         .padding(20)
         .navigationBarBackButtonHidden(true)

--- a/WordRot/Views/GameView.swift
+++ b/WordRot/Views/GameView.swift
@@ -50,5 +50,6 @@ struct GameView_Previews: PreviewProvider {
     static var previews: some View {
         let game = Game()
         GameView(game: game)
+            .preferredColorScheme(.dark)
     }
 }

--- a/WordRot/Views/GameView.swift
+++ b/WordRot/Views/GameView.swift
@@ -12,10 +12,7 @@ struct GameView: View {
             Text("score: \(game.score)")
                 .font(Font.futura(30))
             
-            NavigationLink("words", destination: WordsView(game: game))
-                .buttonStyle(.bordered)
-                .foregroundColor(Color.white)
-                .font(Font.futura(30))
+            RottenLink("words", destination: WordsView(game: game))
             
             TextField("", text: $word)
                 .textFieldStyle(.roundedBorder)

--- a/WordRot/Views/GameView.swift
+++ b/WordRot/Views/GameView.swift
@@ -21,10 +21,7 @@ struct GameView: View {
                 .textFieldStyle(.roundedBorder)
             
             HStack(spacing: 20) {
-                Button("play", action: playWord)
-                    .buttonStyle(.bordered)
-                    .foregroundColor(Color.white)
-                    .font(Font.futura(30))
+                RottenButton("play", action: playWord)
                 
                 if let message = game.lastError {
                     Text(message)
@@ -32,10 +29,7 @@ struct GameView: View {
                 }
             }
             
-            Button("quit", action: quitGame)
-                .buttonStyle(.bordered)
-                .font(Font.futura(30))
-                .foregroundColor(Color.white)
+            RottenButton("quit", action: quitGame)
         }
         .padding(20)
         .navigationBarBackButtonHidden(true)

--- a/WordRot/Views/GameView.swift
+++ b/WordRot/Views/GameView.swift
@@ -29,7 +29,7 @@ struct GameView: View {
             RottenButton("quit", action: quitGame)
         }
         .padding(20)
-        .navigationBarBackButtonHidden(true)
+        .navigationBarHidden(true)
     }
     
     func playWord() {

--- a/WordRot/Views/RottenButton.swift
+++ b/WordRot/Views/RottenButton.swift
@@ -1,0 +1,38 @@
+//
+//  RottenButton.swift
+//  WordRot
+//
+//  Created by Jonathan Allured on 2/26/22.
+//
+
+import SwiftUI
+
+struct RottenButton: View {
+    let text: String
+    let action: () -> Void
+    
+    init(_ text: String, action: @escaping () -> Void) {
+        self.text = text
+        self.action = action
+    }
+    
+    var body: some View {
+        Button(text.uppercased(), action: action)
+            .padding([.top, .bottom], 6)
+            .padding([.leading, .trailing], 12)
+            .font(Font.futura(18))
+            .foregroundColor(Color.black)
+            .background(Color.white)
+            .clipShape(Capsule())
+    }
+}
+
+struct RottenButton_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack() {
+            RottenButton("start", action: {})
+            RottenButton("quit", action: {})
+        }
+        .preferredColorScheme(.dark)
+    }
+}

--- a/WordRot/Views/RottenLink.swift
+++ b/WordRot/Views/RottenLink.swift
@@ -1,16 +1,16 @@
 import SwiftUI
 
-struct RottenButton: View {
+struct RottenLink<Destination>: View where Destination: View {
     let text: String
-    let action: () -> Void
+    let destination: Destination
     
-    init(_ text: String, action: @escaping () -> Void) {
+    init(_ text: String, destination: Destination) {
         self.text = text
-        self.action = action
+        self.destination = destination
     }
     
     var body: some View {
-        Button(text.uppercased(), action: action)
+        NavigationLink(text.uppercased(), destination: destination)
             .padding([.top, .bottom], 6)
             .padding([.leading, .trailing], 12)
             .font(Font.futura(18))
@@ -20,11 +20,11 @@ struct RottenButton: View {
     }
 }
 
-struct RottenButton_Previews: PreviewProvider {
+struct RottenLink_Previews: PreviewProvider {
     static var previews: some View {
         VStack() {
-            RottenButton("start", action: {})
-            RottenButton("quit", action: {})
+            RottenLink("start", destination: EmptyView())
+            RottenLink("quit", destination: EmptyView())
         }
         .preferredColorScheme(.dark)
     }

--- a/WordRot/Views/TitleView.swift
+++ b/WordRot/Views/TitleView.swift
@@ -21,5 +21,6 @@ struct TitleView_Previews: PreviewProvider {
     static var previews: some View {
         let store = GameStore()
         TitleView(store: store)
+            .preferredColorScheme(.dark)
     }
 }

--- a/WordRot/Views/TitleView.swift
+++ b/WordRot/Views/TitleView.swift
@@ -8,10 +8,13 @@ struct TitleView: View {
         
         NavigationView {
             VStack {
-                Text("word rot").foregroundColor(.black)
+                Text("word rot")
+                    .foregroundColor(Color.complete)
+                    .font(Font.futura(30))
                 NavigationLink("start", destination: gameView)
                     .buttonStyle(.bordered)
-                    .foregroundColor(.black)
+                    .foregroundColor(Color.white)
+                    .font(Font.futura(30))
             }
         }
     }

--- a/WordRot/Views/TitleView.swift
+++ b/WordRot/Views/TitleView.swift
@@ -11,10 +11,7 @@ struct TitleView: View {
                 Text("word rot")
                     .foregroundColor(Color.complete)
                     .font(Font.futura(30))
-                NavigationLink("start", destination: gameView)
-                    .buttonStyle(.bordered)
-                    .foregroundColor(Color.white)
-                    .font(Font.futura(30))
+                RottenLink("start", destination: gameView)
             }
         }
     }

--- a/WordRot/Views/WordsView.swift
+++ b/WordRot/Views/WordsView.swift
@@ -9,10 +9,12 @@ struct WordsView: View {
         VStack(alignment: .leading, spacing: 30) {
             HStack() {
                 Text("Played Words")
+                    .font(Font.futura(30))
                 Spacer()
                 Button("done", action: handleDonePress)
                     .buttonStyle(.bordered)
-                    .foregroundColor(.black)
+                    .font(Font.futura(30))
+                    .foregroundColor(Color.white)
             }
             
             ForEach(game.playedWords, id: \.self) { word in

--- a/WordRot/Views/WordsView.swift
+++ b/WordRot/Views/WordsView.swift
@@ -11,10 +11,7 @@ struct WordsView: View {
                 Text("Played Words")
                     .font(Font.futura(30))
                 Spacer()
-                Button("done", action: handleDonePress)
-                    .buttonStyle(.bordered)
-                    .font(Font.futura(30))
-                    .foregroundColor(Color.white)
+                RottenButton("done", action: handleDonePress)
             }
             
             ForEach(game.playedWords, id: \.self) { word in

--- a/WordRot/Views/WordsView.swift
+++ b/WordRot/Views/WordsView.swift
@@ -20,8 +20,8 @@ struct WordsView: View {
             
             Spacer()
         }
-        .padding(30)
-        .navigationBarBackButtonHidden(true)
+        .padding(20)
+        .navigationBarHidden(true)
     }
     
     func handleDonePress() {

--- a/WordRot/Views/WordsView.swift
+++ b/WordRot/Views/WordsView.swift
@@ -6,7 +6,7 @@ struct WordsView: View {
     @ObservedObject var game: Game
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 30) {
+        VStack(alignment: .leading, spacing: 20) {
             HStack() {
                 Text("Played Words")
                     .font(Font.futura(30))
@@ -16,6 +16,7 @@ struct WordsView: View {
             
             ForEach(game.playedWords, id: \.self) { word in
                 Text(word)
+                    .font(Font.futura(20))
             }
             
             Spacer()
@@ -33,6 +34,6 @@ struct WordsView_Previews: PreviewProvider {
     static var previews: some View {
         let game = Game()
         game.playedWords = ["Foo", "Bar"]
-        return WordsView(game: game)
+        return WordsView(game: game).preferredColorScheme(.dark)
     }
 }

--- a/WordRot/WordRotApp.swift
+++ b/WordRot/WordRotApp.swift
@@ -12,7 +12,7 @@ struct WordRotApp: App {
     var body: some Scene {
         WindowGroup {
             TitleView(store: GameStore.shared)
-                .preferredColorScheme(.light)
+                .preferredColorScheme(.dark)
         }
     }
 }


### PR DESCRIPTION
This PR starts the work of styling the game with colors and fonts. Looks like this:
<img width="564" alt="Screen Shot 2022-02-26 at 4 52 17 PM" src="https://user-images.githubusercontent.com/79799/155861572-f0b6c639-dcb8-4f2b-9f81-5e2bc829a7b5.png">
<img width="564" alt="Screen Shot 2022-02-26 at 4 52 21 PM" src="https://user-images.githubusercontent.com/79799/155861573-8b73e315-03c1-4500-9229-1f931fe05735.png">
<img width="564" alt="Screen Shot 2022-02-26 at 4 52 24 PM" src="https://user-images.githubusercontent.com/79799/155861574-395d59bd-65e4-4c0f-b8b5-b12e1ca312e0.png">

