### PR TITLE
Do nothing with empty word, reject short words

### DIFF
--- a/WordRot/Models/Game.swift
+++ b/WordRot/Models/Game.swift
@@ -10,6 +10,7 @@ class Game: ObservableObject {
     
     func playWord(_ word: String) {
         guard !playedWords.contains(word) else { lastError = "word already played"; return }
+        guard word.count > 3 else { lastError = "word too short"; return }
         guard Dictionary.shared.isValid(word) else { lastError = "word not found"; return }
         
         playedWords.append(word)

--- a/WordRot/Views/GameView.swift
+++ b/WordRot/Views/GameView.swift
@@ -63,6 +63,8 @@ struct GameView: View {
     }
     
     func playWord() {
+        guard word != "" else { return }
+        
         game.playWord(word.lowercased())
         
         if game.lastError == nil {
@@ -71,6 +73,8 @@ struct GameView: View {
     }
     
     func deleteLetter() {
+        guard word != "" else { return }
+        
         word.removeLast()
     }
     


### PR DESCRIPTION
Prior to this PR tapping delete with an empty word would crash the app. This fixes it by doing nothing on delete with an empty word. I also implemented this same do nothing with the play button. Then I also updated the Game to reject words shorter than 4 characters.