### PR TITLE
Improve delete

### DIFF
--- a/WordRot/Models/LetterBoard.swift
+++ b/WordRot/Models/LetterBoard.swift
@@ -42,8 +42,20 @@ class LetterBoard {
     }
     
     let letterRows: [LetterRow]
+    var rackedLetters: [LetterTile] = []
     
     init(letterRows: [LetterRow]) {
         self.letterRows = letterRows
+    }
+    
+    func rackLetter(letterTile: LetterTile) {
+        rackedLetters.append(letterTile)
+    }
+    
+    func removeLastRacked() {
+        guard let lastRacked = rackedLetters.last else { return }
+        
+        lastRacked.racked.toggle()
+        rackedLetters.removeLast()
     }
 }

--- a/WordRot/Views/GameView.swift
+++ b/WordRot/Views/GameView.swift
@@ -49,7 +49,7 @@ struct GameView: View {
             GeometryReader { proxy in
                 VStack() {
                     Spacer()
-                    LetterBoardView(updateWord: updateWord)
+                    LetterBoardView(deleteLetter: deleteLetter, updateWord: updateWord)
                         .frame(width: proxy.size.width, height: proxy.size.width)
                 }
             }
@@ -75,6 +75,7 @@ struct GameView: View {
     func deleteLetter() {
         guard word != "" else { return }
         
+        game.letterBoard.removeLastRacked()
         word.removeLast()
     }
     

--- a/WordRot/Views/LetterBoardView.swift
+++ b/WordRot/Views/LetterBoardView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct LetterRowsView: View {
+    let deleteLetter: () -> Void
     let updateWord: (String) -> Void
     
     var letterRows: [LetterRow] {
@@ -10,13 +11,14 @@ struct LetterRowsView: View {
     var body: some View {
         VStack(spacing: 0) {
             ForEach(letterRows) { letterRow in
-                LetterRowView(letterRow: letterRow, updateWord: updateWord)
+                LetterRowView(letterRow: letterRow, deleteLetter: deleteLetter, updateWord: updateWord)
             }
         }
     }
 }
 
 struct LetterBoardView: View {
+    let deleteLetter: () -> Void
     let updateWord: (String) -> Void
     
     var letterRows: [LetterRow] {
@@ -26,7 +28,7 @@ struct LetterBoardView: View {
     var body: some View {
         ZStack() {
             CirclesView()
-            LetterRowsView(updateWord: updateWord)
+            LetterRowsView(deleteLetter: deleteLetter, updateWord: updateWord)
                 .background(.ultraThinMaterial)
         }
         .clipped()
@@ -35,8 +37,9 @@ struct LetterBoardView: View {
 
 struct LetterBoardView_Previews: PreviewProvider {
     static var previews: some View {
+        func noop() {}
         func noop(s: String) {}
-        return LetterBoardView(updateWord: noop)
+        return LetterBoardView(deleteLetter: noop, updateWord: noop)
             .preferredColorScheme(.dark)
             .frame(width: 300, height: 300)
     }

--- a/WordRot/Views/LetterRowView.swift
+++ b/WordRot/Views/LetterRowView.swift
@@ -2,12 +2,13 @@ import SwiftUI
 
 struct LetterRowView: View {
     let letterRow: LetterRow
+    let deleteLetter: () -> Void
     let updateWord: (String) -> Void
     
     var body: some View {
         HStack(spacing: 0) {
             ForEach(letterRow.letterTiles) { letterTile in
-                LetterTileView(letterTile: letterTile, updateWord: updateWord)
+                LetterTileView(letterTile: letterTile, deleteLetter: deleteLetter, updateWord: updateWord)
             }
         }
     }

--- a/WordRot/Views/LetterTileView.swift
+++ b/WordRot/Views/LetterTileView.swift
@@ -13,6 +13,7 @@ struct LetterTileView: View {
     @State private var animateGradient = false
     @ObservedObject var letterTile: LetterTile
     
+    let deleteLetter: () -> Void
     let updateWord: (String) -> Void
     
     var opacity: CGFloat {
@@ -38,8 +39,13 @@ struct LetterTileView: View {
     }
     
     func handlePress() {
-        // maybe what i do here is invoke a func from the GameView so that it can update its `word` property?
-        updateWord(letterTile.letter)
+        if letterTile.racked {
+            deleteLetter()
+        } else {
+            GameStore.shared.currentGame.letterBoard.rackLetter(letterTile: letterTile)
+            updateWord(letterTile.letter)
+        }
+        
         letterTile.update()
     }
 }


### PR DESCRIPTION
There were some bugs around deleting or tapping a racked letter so this gets everybody to agree about the state of the played word. I did this by introducing a new `rackedLetter` property to the `LetterBoard`. It is an array that is added to and removed from as letters are added to the rack.

I think there's a missing bit here where I extract the `word` property from the `GameView` and have the `LetterBoard` provide this string instead but I didn't want to get wrapped up in that right now.