### PR TITLE
Improve letter distribution

### DIFF
--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		FC11EB8427C6BB8600346270 /* LetterBoard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11EB8327C6BB8600346270 /* LetterBoard.swift */; };
 		FC11EB8627C6C00B00346270 /* LetterRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11EB8527C6C00B00346270 /* LetterRowView.swift */; };
 		FC11EB8827C6C05100346270 /* LetterTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11EB8727C6C05100346270 /* LetterTileView.swift */; };
+		FC5FB12627D536B50042FBCC /* BoardMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB12527D536B50042FBCC /* BoardMaker.swift */; };
 		FC84210D27CADE620035E151 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210C27CADE620035E151 /* Color.swift */; };
 		FC84210F27CADE9D0035E151 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210E27CADE9D0035E151 /* Font.swift */; };
 		FC84211127CAE07D0035E151 /* RottenButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84211027CAE07D0035E151 /* RottenButton.swift */; };
@@ -65,6 +66,7 @@
 		FC11EB8327C6BB8600346270 /* LetterBoard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterBoard.swift; sourceTree = "<group>"; };
 		FC11EB8527C6C00B00346270 /* LetterRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterRowView.swift; sourceTree = "<group>"; };
 		FC11EB8727C6C05100346270 /* LetterTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterTileView.swift; sourceTree = "<group>"; };
+		FC5FB12527D536B50042FBCC /* BoardMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMaker.swift; sourceTree = "<group>"; };
 		FC84210C27CADE620035E151 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		FC84210E27CADE9D0035E151 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 		FC84211027CAE07D0035E151 /* RottenButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RottenButton.swift; sourceTree = "<group>"; };
@@ -129,6 +131,7 @@
 		FC036FC927C59ECD00325826 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				FC5FB12527D536B50042FBCC /* BoardMaker.swift */,
 				FC036FD327C5F2A500325826 /* Dictionary.swift */,
 				FC09A6FE27AF811600715D3E /* Game.swift */,
 				FC036FCA27C59F2100325826 /* GameStore.swift */,
@@ -351,6 +354,7 @@
 				FC8F74B127A4831400779157 /* GameView.swift in Sources */,
 				FC8F74AF27A4831400779157 /* WordRotApp.swift in Sources */,
 				FC036FCD27C5DAF100325826 /* WordsView.swift in Sources */,
+				FC5FB12627D536B50042FBCC /* BoardMaker.swift in Sources */,
 				FC84211327CAE2550035E151 /* RottenLink.swift in Sources */,
 				FC09A6FD27AF4BDB00715D3E /* TitleView.swift in Sources */,
 				FC036FD427C5F2A500325826 /* Dictionary.swift in Sources */,

--- a/WordRot/Models/BoardMaker.swift
+++ b/WordRot/Models/BoardMaker.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+class BoardMaker {
+    static func fill() -> [[LetterPair]] {
+        let rows = 5
+        let columns = 5
+        
+        let totalLetters = rows * columns
+
+        let maker = BoardMaker(totalLetters: totalLetters)
+        maker.fill()
+        let letters = maker.letters
+        
+        let data: [[LetterPair]] = Array(0..<rows).map { row in
+            return Array(0..<columns).map { column in
+                let index = (row * rows) + column
+                return letters[index]
+            }
+        }
+        
+        return data
+    }
+    
+    let totalLetters: Int
+    
+    var vowels = [
+        "a", "a", "e", "e", "e", "i", "i", "o", "o", "u"
+    ]
+    
+    var consonants = [
+        "b", "c", "d", "f", "g", "h",
+        "j", "k", "l", "m", "n",
+        "p", "q", "r", "s", "t",
+        "v", "w", "x", "y", "z"
+    ]
+    
+    var letters: [LetterPair] = []
+    
+    init(totalLetters: Int) {
+        self.totalLetters = totalLetters
+    }
+    
+    func fill() {
+        addVowels()
+        addDupes()
+        addConsonants()
+        shuffleLetters()
+    }
+    
+    func addVowels() {
+        let vowelCount = Int.random(in: 3...6)
+        
+        for _ in 1...vowelCount {
+            let letter = vowels.remove(at: Int.random(in: 0..<vowels.count))
+            letters.append((letter, 2))
+        }
+    }
+    
+    func addDupes() {
+        let dupeCount = Int.random(in: 1...3)
+        
+        for _ in 1...dupeCount {
+            let letter = consonants.remove(at: Int.random(in: 0..<consonants.count))
+            letters.append((letter, 2))
+            letters.append((letter, 2))
+        }
+    }
+    
+    func addConsonants() {
+        let remainingCount = totalLetters - letters.count
+        
+        for _ in 1...remainingCount {
+            let letter = consonants.remove(at: Int.random(in: 0..<consonants.count))
+            letters.append((letter, 2))
+        }
+    }
+    
+    func shuffleLetters() {
+        letters.shuffle()
+    }
+}

--- a/WordRot/Models/LetterBoard.swift
+++ b/WordRot/Models/LetterBoard.swift
@@ -2,29 +2,9 @@ import Foundation
 
 typealias LetterPair = (String, Int)
 
-let alphabet = [
-    "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
-    "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
-]
-
 class LetterBoard {
-    static func makeLetterPair() -> LetterPair {
-        let initialRot = Int.random(in: 0...5)
-        let initialLetterIndex = Int.random(in: 0...25)
-        let initialLetter = alphabet[initialLetterIndex]
-        
-        return (initialLetter, initialRot)
-    }
-    
     static func start() -> LetterBoard {
-        let rows = 5
-        let columns = 5
-        
-        let data: [[LetterPair]] = Array(1...rows).map { _ in
-            return Array(1...columns).map { _ in
-                return makeLetterPair()
-            }
-        }
+        let data = BoardMaker.fill()
         
         let letterRows: [LetterRow] = data.map { letters in
             let tiles = letters.map() { letterPair in

--- a/WordRot/Views/LetterTileView.swift
+++ b/WordRot/Views/LetterTileView.swift
@@ -44,9 +44,8 @@ struct LetterTileView: View {
         } else {
             GameStore.shared.currentGame.letterBoard.rackLetter(letterTile: letterTile)
             updateWord(letterTile.letter)
+            letterTile.update()
         }
-        
-        letterTile.update()
     }
 }
 


### PR DESCRIPTION
This PR adds a new class called `BoardMaker` inspired from my legacy version of Word Rot. It's not totally complete but it does do a better job of making a set of letters that's more fun to play with. The rough outline of what it does is in the `fill` method:

* add some vowels
* add some consonants with duplicates
* fill to the total letter count
* shuffle the letters around