### PR TITLE
Scores screen

### DIFF
--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		FC462C9027E7CB63001B1B10 /* 2-CreateRoundsMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8F27E7CB63001B1B10 /* 2-CreateRoundsMigration.swift */; };
 		FC462C9227E7CC74001B1B10 /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C9127E7CC74001B1B10 /* Migration.swift */; };
 		FC5FB12627D536B50042FBCC /* BoardMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB12527D536B50042FBCC /* BoardMaker.swift */; };
+		FC6A792527EF6BE0001272DA /* ScoresScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6A792427EF6BE0001272DA /* ScoresScreen.swift */; };
+		FC6A792727F0FF51001272DA /* RottenRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC6A792627F0FF51001272DA /* RottenRecord.swift */; };
 		FC84210D27CADE620035E151 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210C27CADE620035E151 /* Color.swift */; };
 		FC84210F27CADE9D0035E151 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210E27CADE9D0035E151 /* Font.swift */; };
 		FC84211127CAE07D0035E151 /* RottenButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84211027CAE07D0035E151 /* RottenButton.swift */; };
@@ -85,6 +87,8 @@
 		FC462C8F27E7CB63001B1B10 /* 2-CreateRoundsMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "2-CreateRoundsMigration.swift"; sourceTree = "<group>"; };
 		FC462C9127E7CC74001B1B10 /* Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
 		FC5FB12527D536B50042FBCC /* BoardMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMaker.swift; sourceTree = "<group>"; };
+		FC6A792427EF6BE0001272DA /* ScoresScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScoresScreen.swift; sourceTree = "<group>"; };
+		FC6A792627F0FF51001272DA /* RottenRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RottenRecord.swift; sourceTree = "<group>"; };
 		FC84210C27CADE620035E151 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		FC84210E27CADE9D0035E151 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
 		FC84211027CAE07D0035E151 /* RottenButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RottenButton.swift; sourceTree = "<group>"; };
@@ -157,6 +161,7 @@
 				FC11EB7F27C6BA9600346270 /* LetterRow.swift */,
 				FC11EB8127C6BAD200346270 /* LetterTile.swift */,
 				FC462C8727E7954B001B1B10 /* Loader.swift */,
+				FC6A792627F0FF51001272DA /* RottenRecord.swift */,
 				FC00B1EC27E947ED009843F3 /* Round.swift */,
 			);
 			path = Models;
@@ -194,10 +199,11 @@
 			isa = PBXGroup;
 			children = (
 				FC8F74B027A4831400779157 /* GameScreen.swift */,
-				FC036FCC27C5DAF100325826 /* RoundsScreen.swift */,
-				FC09A6FC27AF4BDB00715D3E /* TitleScreen.swift */,
-				FC861A4B27DD42AB005CE3F3 /* SplashScreen.swift */,
 				FC861A4D27DD431E005CE3F3 /* RootScreen.swift */,
+				FC036FCC27C5DAF100325826 /* RoundsScreen.swift */,
+				FC6A792427EF6BE0001272DA /* ScoresScreen.swift */,
+				FC861A4B27DD42AB005CE3F3 /* SplashScreen.swift */,
+				FC09A6FC27AF4BDB00715D3E /* TitleScreen.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -411,6 +417,7 @@
 				FC8F74AF27A4831400779157 /* WordRotApp.swift in Sources */,
 				FC462C8B27E7BD63001B1B10 /* RottenDB.swift in Sources */,
 				FC036FCD27C5DAF100325826 /* RoundsScreen.swift in Sources */,
+				FC6A792727F0FF51001272DA /* RottenRecord.swift in Sources */,
 				FC5FB12627D536B50042FBCC /* BoardMaker.swift in Sources */,
 				FC84211327CAE2550035E151 /* RottenLink.swift in Sources */,
 				FC861A4C27DD42AB005CE3F3 /* SplashScreen.swift in Sources */,
@@ -418,6 +425,7 @@
 				FC462C9227E7CC74001B1B10 /* Migration.swift in Sources */,
 				FC09A6FD27AF4BDB00715D3E /* TitleScreen.swift in Sources */,
 				FC036FD427C5F2A500325826 /* Dictionary.swift in Sources */,
+				FC6A792527EF6BE0001272DA /* ScoresScreen.swift in Sources */,
 				FC462C8E27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift in Sources */,
 				FC84210F27CADE9D0035E151 /* Font.swift in Sources */,
 				FC462C8827E7954B001B1B10 /* Loader.swift in Sources */,

--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		FC00B1ED27E947ED009843F3 /* Round.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC00B1EC27E947ED009843F3 /* Round.swift */; };
 		FC036FCB27C59F2100325826 /* GameStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC036FCA27C59F2100325826 /* GameStore.swift */; };
 		FC036FCD27C5DAF100325826 /* RoundsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC036FCC27C5DAF100325826 /* RoundsScreen.swift */; };
 		FC036FD427C5F2A500325826 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC036FD327C5F2A500325826 /* Dictionary.swift */; };
@@ -63,6 +64,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		FC00B1EC27E947ED009843F3 /* Round.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Round.swift; sourceTree = "<group>"; };
 		FC036FCA27C59F2100325826 /* GameStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameStore.swift; sourceTree = "<group>"; };
 		FC036FCC27C5DAF100325826 /* RoundsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundsScreen.swift; sourceTree = "<group>"; };
 		FC036FD327C5F2A500325826 /* Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
@@ -155,6 +157,7 @@
 				FC11EB7F27C6BA9600346270 /* LetterRow.swift */,
 				FC11EB8127C6BAD200346270 /* LetterTile.swift */,
 				FC462C8727E7954B001B1B10 /* Loader.swift */,
+				FC00B1EC27E947ED009843F3 /* Round.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -401,6 +404,7 @@
 			files = (
 				FC11EB8827C6C05100346270 /* LetterTileView.swift in Sources */,
 				FC11EB8427C6BB8600346270 /* LetterBoard.swift in Sources */,
+				FC00B1ED27E947ED009843F3 /* Round.swift in Sources */,
 				FCF464C327CAEEA5009E467B /* CirclesView.swift in Sources */,
 				FC11EB8627C6C00B00346270 /* LetterRowView.swift in Sources */,
 				FC8F74B127A4831400779157 /* GameScreen.swift in Sources */,

--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		FC462C8827E7954B001B1B10 /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8727E7954B001B1B10 /* Loader.swift */; };
 		FC462C8B27E7BD63001B1B10 /* RottenDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8A27E7BD63001B1B10 /* RottenDB.swift */; };
 		FC462C8E27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8D27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift */; };
+		FC462C9027E7CB63001B1B10 /* 2-CreateRoundsMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8F27E7CB63001B1B10 /* 2-CreateRoundsMigration.swift */; };
+		FC462C9227E7CC74001B1B10 /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C9127E7CC74001B1B10 /* Migration.swift */; };
 		FC5FB12627D536B50042FBCC /* BoardMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB12527D536B50042FBCC /* BoardMaker.swift */; };
 		FC84210D27CADE620035E151 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210C27CADE620035E151 /* Color.swift */; };
 		FC84210F27CADE9D0035E151 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210E27CADE9D0035E151 /* Font.swift */; };
@@ -78,6 +80,8 @@
 		FC462C8727E7954B001B1B10 /* Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
 		FC462C8A27E7BD63001B1B10 /* RottenDB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RottenDB.swift; sourceTree = "<group>"; };
 		FC462C8D27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "1-CreateGamesMigration.swift"; sourceTree = "<group>"; };
+		FC462C8F27E7CB63001B1B10 /* 2-CreateRoundsMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "2-CreateRoundsMigration.swift"; sourceTree = "<group>"; };
+		FC462C9127E7CC74001B1B10 /* Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
 		FC5FB12527D536B50042FBCC /* BoardMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMaker.swift; sourceTree = "<group>"; };
 		FC84210C27CADE620035E151 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		FC84210E27CADE9D0035E151 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
@@ -168,6 +172,8 @@
 			isa = PBXGroup;
 			children = (
 				FC462C8D27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift */,
+				FC462C8F27E7CB63001B1B10 /* 2-CreateRoundsMigration.swift */,
+				FC462C9127E7CC74001B1B10 /* Migration.swift */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -405,6 +411,7 @@
 				FC84211327CAE2550035E151 /* RottenLink.swift in Sources */,
 				FC861A4C27DD42AB005CE3F3 /* SplashScreen.swift in Sources */,
 				FC462C8627E79500001B1B10 /* Killswitch.swift in Sources */,
+				FC462C9227E7CC74001B1B10 /* Migration.swift in Sources */,
 				FC09A6FD27AF4BDB00715D3E /* TitleScreen.swift in Sources */,
 				FC036FD427C5F2A500325826 /* Dictionary.swift in Sources */,
 				FC462C8E27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift in Sources */,
@@ -417,6 +424,7 @@
 				FC11EB7E27C6BA3600346270 /* LetterBoardView.swift in Sources */,
 				FCF464C527CAEF09009E467B /* RottenCircleView.swift in Sources */,
 				FC11EB8227C6BAD200346270 /* LetterTile.swift in Sources */,
+				FC462C9027E7CB63001B1B10 /* 2-CreateRoundsMigration.swift in Sources */,
 				FC036FCB27C59F2100325826 /* GameStore.swift in Sources */,
 				FC09A6FF27AF811600715D3E /* Game.swift in Sources */,
 			);

--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		FC462C8627E79500001B1B10 /* Killswitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8527E79500001B1B10 /* Killswitch.swift */; };
 		FC462C8827E7954B001B1B10 /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8727E7954B001B1B10 /* Loader.swift */; };
 		FC462C8B27E7BD63001B1B10 /* RottenDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8A27E7BD63001B1B10 /* RottenDB.swift */; };
+		FC462C8E27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8D27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift */; };
 		FC5FB12627D536B50042FBCC /* BoardMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB12527D536B50042FBCC /* BoardMaker.swift */; };
 		FC84210D27CADE620035E151 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210C27CADE620035E151 /* Color.swift */; };
 		FC84210F27CADE9D0035E151 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210E27CADE9D0035E151 /* Font.swift */; };
@@ -76,6 +77,7 @@
 		FC462C8527E79500001B1B10 /* Killswitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Killswitch.swift; sourceTree = "<group>"; };
 		FC462C8727E7954B001B1B10 /* Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
 		FC462C8A27E7BD63001B1B10 /* RottenDB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RottenDB.swift; sourceTree = "<group>"; };
+		FC462C8D27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "1-CreateGamesMigration.swift"; sourceTree = "<group>"; };
 		FC5FB12527D536B50042FBCC /* BoardMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMaker.swift; sourceTree = "<group>"; };
 		FC84210C27CADE620035E151 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		FC84210E27CADE9D0035E151 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
@@ -156,9 +158,18 @@
 		FC462C8927E7BD53001B1B10 /* Database */ = {
 			isa = PBXGroup;
 			children = (
+				FC462C8C27E7C49B001B1B10 /* Migrations */,
 				FC462C8A27E7BD63001B1B10 /* RottenDB.swift */,
 			);
 			path = Database;
+			sourceTree = "<group>";
+		};
+		FC462C8C27E7C49B001B1B10 /* Migrations */ = {
+			isa = PBXGroup;
+			children = (
+				FC462C8D27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift */,
+			);
+			path = Migrations;
 			sourceTree = "<group>";
 		};
 		FC84210B27CADE540035E151 /* Extensions */ = {
@@ -205,8 +216,8 @@
 		FC8F74AD27A4831400779157 /* WordRot */ = {
 			isa = PBXGroup;
 			children = (
-				FC462C8927E7BD53001B1B10 /* Database */,
 				FC8F74B227A4831600779157 /* Assets.xcassets */,
+				FC462C8927E7BD53001B1B10 /* Database */,
 				FC84210B27CADE540035E151 /* Extensions */,
 				FC462C8327E6849F001B1B10 /* LaunchScreen.storyboard */,
 				FC036FC927C59ECD00325826 /* Models */,
@@ -396,6 +407,7 @@
 				FC462C8627E79500001B1B10 /* Killswitch.swift in Sources */,
 				FC09A6FD27AF4BDB00715D3E /* TitleScreen.swift in Sources */,
 				FC036FD427C5F2A500325826 /* Dictionary.swift in Sources */,
+				FC462C8E27E7C4B7001B1B10 /* 1-CreateGamesMigration.swift in Sources */,
 				FC84210F27CADE9D0035E151 /* Font.swift in Sources */,
 				FC462C8827E7954B001B1B10 /* Loader.swift in Sources */,
 				FC861A4E27DD431E005CE3F3 /* RootScreen.swift in Sources */,

--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		FC036FCB27C59F2100325826 /* GameStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC036FCA27C59F2100325826 /* GameStore.swift */; };
 		FC036FCD27C5DAF100325826 /* RoundsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC036FCC27C5DAF100325826 /* RoundsScreen.swift */; };
 		FC036FD427C5F2A500325826 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC036FD327C5F2A500325826 /* Dictionary.swift */; };
-		FC036FD927C5F9D500325826 /* words.sqlite3 in Resources */ = {isa = PBXBuildFile; fileRef = FC036FD627C5F67200325826 /* words.sqlite3 */; };
+		FC036FD927C5F9D500325826 /* rotten.sqlite3 in Resources */ = {isa = PBXBuildFile; fileRef = FC036FD627C5F67200325826 /* rotten.sqlite3 */; };
 		FC09A6FD27AF4BDB00715D3E /* TitleScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC09A6FC27AF4BDB00715D3E /* TitleScreen.swift */; };
 		FC09A6FF27AF811600715D3E /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC09A6FE27AF811600715D3E /* Game.swift */; };
 		FC11EB7C27C69AAE00346270 /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = FC11EB7B27C69AAE00346270 /* SQLite */; };
@@ -60,7 +60,7 @@
 		FC036FCA27C59F2100325826 /* GameStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameStore.swift; sourceTree = "<group>"; };
 		FC036FCC27C5DAF100325826 /* RoundsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundsScreen.swift; sourceTree = "<group>"; };
 		FC036FD327C5F2A500325826 /* Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
-		FC036FD627C5F67200325826 /* words.sqlite3 */ = {isa = PBXFileReference; lastKnownFileType = file; path = words.sqlite3; sourceTree = "<group>"; };
+		FC036FD627C5F67200325826 /* rotten.sqlite3 */ = {isa = PBXFileReference; lastKnownFileType = file; path = rotten.sqlite3; sourceTree = "<group>"; };
 		FC09A6FC27AF4BDB00715D3E /* TitleScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleScreen.swift; sourceTree = "<group>"; };
 		FC09A6FE27AF811600715D3E /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
 		FC11EB7D27C6BA3600346270 /* LetterBoardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterBoardView.swift; sourceTree = "<group>"; };
@@ -191,13 +191,13 @@
 			children = (
 				FC8F74B227A4831600779157 /* Assets.xcassets */,
 				FC84210B27CADE540035E151 /* Extensions */,
+				FC462C8327E6849F001B1B10 /* LaunchScreen.storyboard */,
 				FC036FC927C59ECD00325826 /* Models */,
 				FC8F74B427A4831600779157 /* Preview Content */,
+				FC036FD627C5F67200325826 /* rotten.sqlite3 */,
 				FC861A4A27DD41AE005CE3F3 /* Screens */,
 				FC036FC827C59EB300325826 /* Views */,
 				FC8F74AE27A4831400779157 /* WordRotApp.swift */,
-				FC036FD627C5F67200325826 /* words.sqlite3 */,
-				FC462C8327E6849F001B1B10 /* LaunchScreen.storyboard */,
 			);
 			path = WordRot;
 			sourceTree = "<group>";
@@ -340,7 +340,7 @@
 				FC8F74B627A4831600779157 /* Preview Assets.xcassets in Resources */,
 				FC462C8427E6849F001B1B10 /* LaunchScreen.storyboard in Resources */,
 				FC8F74B327A4831600779157 /* Assets.xcassets in Resources */,
-				FC036FD927C5F9D500325826 /* words.sqlite3 in Resources */,
+				FC036FD927C5F9D500325826 /* rotten.sqlite3 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		FC462C8427E6849F001B1B10 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FC462C8327E6849F001B1B10 /* LaunchScreen.storyboard */; };
 		FC462C8627E79500001B1B10 /* Killswitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8527E79500001B1B10 /* Killswitch.swift */; };
 		FC462C8827E7954B001B1B10 /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8727E7954B001B1B10 /* Loader.swift */; };
+		FC462C8B27E7BD63001B1B10 /* RottenDB.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8A27E7BD63001B1B10 /* RottenDB.swift */; };
 		FC5FB12627D536B50042FBCC /* BoardMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB12527D536B50042FBCC /* BoardMaker.swift */; };
 		FC84210D27CADE620035E151 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210C27CADE620035E151 /* Color.swift */; };
 		FC84210F27CADE9D0035E151 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210E27CADE9D0035E151 /* Font.swift */; };
@@ -74,6 +75,7 @@
 		FC462C8327E6849F001B1B10 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		FC462C8527E79500001B1B10 /* Killswitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Killswitch.swift; sourceTree = "<group>"; };
 		FC462C8727E7954B001B1B10 /* Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
+		FC462C8A27E7BD63001B1B10 /* RottenDB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RottenDB.swift; sourceTree = "<group>"; };
 		FC5FB12527D536B50042FBCC /* BoardMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMaker.swift; sourceTree = "<group>"; };
 		FC84210C27CADE620035E151 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		FC84210E27CADE9D0035E151 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
@@ -151,6 +153,14 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		FC462C8927E7BD53001B1B10 /* Database */ = {
+			isa = PBXGroup;
+			children = (
+				FC462C8A27E7BD63001B1B10 /* RottenDB.swift */,
+			);
+			path = Database;
+			sourceTree = "<group>";
+		};
 		FC84210B27CADE540035E151 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -195,6 +205,7 @@
 		FC8F74AD27A4831400779157 /* WordRot */ = {
 			isa = PBXGroup;
 			children = (
+				FC462C8927E7BD53001B1B10 /* Database */,
 				FC8F74B227A4831600779157 /* Assets.xcassets */,
 				FC84210B27CADE540035E151 /* Extensions */,
 				FC462C8327E6849F001B1B10 /* LaunchScreen.storyboard */,
@@ -377,6 +388,7 @@
 				FC11EB8627C6C00B00346270 /* LetterRowView.swift in Sources */,
 				FC8F74B127A4831400779157 /* GameScreen.swift in Sources */,
 				FC8F74AF27A4831400779157 /* WordRotApp.swift in Sources */,
+				FC462C8B27E7BD63001B1B10 /* RottenDB.swift in Sources */,
 				FC036FCD27C5DAF100325826 /* RoundsScreen.swift in Sources */,
 				FC5FB12627D536B50042FBCC /* BoardMaker.swift in Sources */,
 				FC84211327CAE2550035E151 /* RottenLink.swift in Sources */,

--- a/WordRot.xcodeproj/project.pbxproj
+++ b/WordRot.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		FC11EB8627C6C00B00346270 /* LetterRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11EB8527C6C00B00346270 /* LetterRowView.swift */; };
 		FC11EB8827C6C05100346270 /* LetterTileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC11EB8727C6C05100346270 /* LetterTileView.swift */; };
 		FC462C8427E6849F001B1B10 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FC462C8327E6849F001B1B10 /* LaunchScreen.storyboard */; };
+		FC462C8627E79500001B1B10 /* Killswitch.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8527E79500001B1B10 /* Killswitch.swift */; };
+		FC462C8827E7954B001B1B10 /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC462C8727E7954B001B1B10 /* Loader.swift */; };
 		FC5FB12627D536B50042FBCC /* BoardMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC5FB12527D536B50042FBCC /* BoardMaker.swift */; };
 		FC84210D27CADE620035E151 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210C27CADE620035E151 /* Color.swift */; };
 		FC84210F27CADE9D0035E151 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC84210E27CADE9D0035E151 /* Font.swift */; };
@@ -70,6 +72,8 @@
 		FC11EB8527C6C00B00346270 /* LetterRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterRowView.swift; sourceTree = "<group>"; };
 		FC11EB8727C6C05100346270 /* LetterTileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LetterTileView.swift; sourceTree = "<group>"; };
 		FC462C8327E6849F001B1B10 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		FC462C8527E79500001B1B10 /* Killswitch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Killswitch.swift; sourceTree = "<group>"; };
+		FC462C8727E7954B001B1B10 /* Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
 		FC5FB12527D536B50042FBCC /* BoardMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMaker.swift; sourceTree = "<group>"; };
 		FC84210C27CADE620035E151 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		FC84210E27CADE9D0035E151 /* Font.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Font.swift; sourceTree = "<group>"; };
@@ -138,9 +142,11 @@
 				FC036FD327C5F2A500325826 /* Dictionary.swift */,
 				FC09A6FE27AF811600715D3E /* Game.swift */,
 				FC036FCA27C59F2100325826 /* GameStore.swift */,
+				FC462C8527E79500001B1B10 /* Killswitch.swift */,
 				FC11EB8327C6BB8600346270 /* LetterBoard.swift */,
 				FC11EB7F27C6BA9600346270 /* LetterRow.swift */,
 				FC11EB8127C6BAD200346270 /* LetterTile.swift */,
+				FC462C8727E7954B001B1B10 /* Loader.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -375,9 +381,11 @@
 				FC5FB12627D536B50042FBCC /* BoardMaker.swift in Sources */,
 				FC84211327CAE2550035E151 /* RottenLink.swift in Sources */,
 				FC861A4C27DD42AB005CE3F3 /* SplashScreen.swift in Sources */,
+				FC462C8627E79500001B1B10 /* Killswitch.swift in Sources */,
 				FC09A6FD27AF4BDB00715D3E /* TitleScreen.swift in Sources */,
 				FC036FD427C5F2A500325826 /* Dictionary.swift in Sources */,
 				FC84210F27CADE9D0035E151 /* Font.swift in Sources */,
+				FC462C8827E7954B001B1B10 /* Loader.swift in Sources */,
 				FC861A4E27DD431E005CE3F3 /* RootScreen.swift in Sources */,
 				FC84210D27CADE620035E151 /* Color.swift in Sources */,
 				FC84211127CAE07D0035E151 /* RottenButton.swift in Sources */,

--- a/WordRot/Database/Migrations/1-CreateGamesMigration.swift
+++ b/WordRot/Database/Migrations/1-CreateGamesMigration.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SQLite
+
+private let sql = """
+create table if not exists games(
+  id integer primary key,
+  status string,
+  created_at default current_timestamp,
+  updated_at default current_timestamp
+)
+"""
+
+struct CreateGamesMigration {
+    static let order: Int32 = 1
+    
+    static func run(client: Connection) {
+        try! client.execute(sql)
+        client.userVersion = order
+    }
+}

--- a/WordRot/Database/Migrations/2-CreateRoundsMigration.swift
+++ b/WordRot/Database/Migrations/2-CreateRoundsMigration.swift
@@ -2,16 +2,18 @@ import Foundation
 import SQLite
 
 private let sql = """
-create table if not exists games(
+create table if not exists rounds(
   id integer primary key,
-  status string,
+  game_id integer,
+  word string,
+  number integer,
   created_at default current_timestamp,
   updated_at default current_timestamp
 )
 """
 
-struct CreateGamesMigration: Migration {
-    let order: Int32 = 1
+struct CreateRoundsMigration: Migration {
+    let order: Int32 = 2
     
     func run(client: Connection) {
         try! client.execute(sql)

--- a/WordRot/Database/Migrations/Migration.swift
+++ b/WordRot/Database/Migrations/Migration.swift
@@ -1,0 +1,7 @@
+import Foundation
+import SQLite
+
+protocol Migration {
+    var order: Int32 { get }
+    func run(client: Connection) -> Void
+}

--- a/WordRot/Database/RottenDB.swift
+++ b/WordRot/Database/RottenDB.swift
@@ -30,6 +30,15 @@ class RottenDB {
         }
     }
     
+    static func runMigrations(client: Connection) {
+        let currentVersion = client.userVersion!
+        let migrations = [
+            CreateGamesMigration.self
+        ]
+        let missingMigrations = migrations.filter { $0.order > currentVersion }
+        missingMigrations.forEach { $0.run(client: client) }
+    }
+    
     static func establishConnection() -> Connection {
         return try! Connection(rottenDbPath)
     }
@@ -38,6 +47,8 @@ class RottenDB {
     
     init() {
         RottenDB.ensureDatabaseFile()
-        self.client = RottenDB.establishConnection()
+        let client = RottenDB.establishConnection()
+        RottenDB.runMigrations(client: client)
+        self.client = client
     }
 }

--- a/WordRot/Database/RottenDB.swift
+++ b/WordRot/Database/RottenDB.swift
@@ -32,8 +32,9 @@ class RottenDB {
     
     static func runMigrations(client: Connection) {
         let currentVersion = client.userVersion!
-        let migrations = [
-            CreateGamesMigration.self
+        let migrations: [Migration] = [
+            CreateGamesMigration(),
+            CreateRoundsMigration()
         ]
         let missingMigrations = migrations.filter { $0.order > currentVersion }
         missingMigrations.forEach { $0.run(client: client) }

--- a/WordRot/Database/RottenDB.swift
+++ b/WordRot/Database/RottenDB.swift
@@ -1,0 +1,43 @@
+import Foundation
+import SQLite
+
+class RottenDB {
+    static private let filename = "rotten.sqlite3"
+    static private let fileManager = FileManager.default
+    
+    static private var documentsUrl: URL {
+        return fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+    }
+    
+    static private var rottenDbPath: String {
+        return documentsUrl.appendingPathComponent(filename).path
+    }
+    
+    static let shared = RottenDB()
+    
+    static var sharedClient: Connection {
+        return shared.client
+    }
+    
+    static func ensureDatabaseFile() {
+        guard !fileManager.fileExists(atPath: rottenDbPath) else { return }
+        
+        do {
+            let sourcePath = Bundle.main.path(forResource: filename, ofType: nil)!
+            try fileManager.copyItem(atPath: sourcePath, toPath: rottenDbPath)
+        } catch {
+            print("error during file copy: \(error)")
+        }
+    }
+    
+    static func establishConnection() -> Connection {
+        return try! Connection(rottenDbPath)
+    }
+    
+    private let client: Connection
+    
+    init() {
+        RottenDB.ensureDatabaseFile()
+        self.client = RottenDB.establishConnection()
+    }
+}

--- a/WordRot/Database/RottenDB.swift
+++ b/WordRot/Database/RottenDB.swift
@@ -52,4 +52,10 @@ class RottenDB {
         RottenDB.runMigrations(client: client)
         self.client = client
     }
+    
+    func selectRows(_ selectSql: String, _ bindings: [Binding] = []) -> [[Binding]] {
+        guard let statement = try? client.run(selectSql, bindings) else { return [] }
+        let rows = statement.compactMap() { element in element.compactMap() { bindings in bindings } }
+        return rows
+    }
 }

--- a/WordRot/Models/Dictionary.swift
+++ b/WordRot/Models/Dictionary.swift
@@ -7,7 +7,7 @@ class Dictionary {
     private let client: Connection
     
     init() {
-        let location = Bundle.main.path(forResource: "words.sqlite3", ofType: nil)!
+        let location = Bundle.main.path(forResource: "rotten.sqlite3", ofType: nil)!
         let client = try! Connection(location)
         self.client = client
     }

--- a/WordRot/Models/Dictionary.swift
+++ b/WordRot/Models/Dictionary.swift
@@ -2,21 +2,9 @@ import Foundation
 import SQLite
 
 class Dictionary {
-    static let shared = Dictionary()
-    
-    private let client: Connection
-    
-    init() {
-        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let location = documentsUrl.appendingPathComponent("rotten.sqlite3").path
-        
-        let client = try! Connection(location)
-        self.client = client
-    }
-    
-    func isValid(_ word: String) -> Bool {
+    static func isValid(_ word: String) -> Bool {
         let query = "select count(*) from words where word = '\(word)'"
-        let count = try! client.scalar(query) as! Int64
+        let count = try! RottenDB.sharedClient.scalar(query) as! Int64
         return count == 1
     }
 }

--- a/WordRot/Models/Dictionary.swift
+++ b/WordRot/Models/Dictionary.swift
@@ -7,7 +7,9 @@ class Dictionary {
     private let client: Connection
     
     init() {
-        let location = Bundle.main.path(forResource: "rotten.sqlite3", ofType: nil)!
+        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let location = documentsUrl.appendingPathComponent("rotten.sqlite3").path
+        
         let client = try! Connection(location)
         self.client = client
     }

--- a/WordRot/Models/Game.swift
+++ b/WordRot/Models/Game.swift
@@ -4,14 +4,26 @@ class Game: ObservableObject {
     @Published var lastError: String?
     @Published var score = 0
     
+    let id: Int
     let letterBoard = LetterBoard.start()
     
     var playedWords: [String] = []
+    var rounds: [Round] = []
+    
+    init() {
+        let sql = "insert into games(status) values('started') returning id;"
+        let id = try! RottenDB.sharedClient.scalar(sql) as! Int64
+        self.id = Int(id)
+    }
     
     func playWord(_ word: String) {
         guard !playedWords.contains(word) else { lastError = "word already played"; return }
         guard word.count > 3 else { lastError = "word too short"; return }
         guard Dictionary.isValid(word) else { lastError = "word not found"; return }
+        
+        let nextRoundNumber = playedWords.count + 1
+        let round = Round(gameId: id, word: word, number: nextRoundNumber)
+        rounds.append(round)
         
         playedWords.append(word)
         score += word.count

--- a/WordRot/Models/Game.swift
+++ b/WordRot/Models/Game.swift
@@ -11,7 +11,7 @@ class Game: ObservableObject {
     func playWord(_ word: String) {
         guard !playedWords.contains(word) else { lastError = "word already played"; return }
         guard word.count > 3 else { lastError = "word too short"; return }
-        guard Dictionary.shared.isValid(word) else { lastError = "word not found"; return }
+        guard Dictionary.isValid(word) else { lastError = "word not found"; return }
         
         playedWords.append(word)
         score += word.count

--- a/WordRot/Models/Game.swift
+++ b/WordRot/Models/Game.swift
@@ -21,12 +21,16 @@ class Game: ObservableObject {
         guard word.count > 3 else { lastError = "word too short"; return }
         guard Dictionary.isValid(word) else { lastError = "word not found"; return }
         
-        let nextRoundNumber = playedWords.count + 1
-        let round = Round(gameId: id, word: word, number: nextRoundNumber)
-        rounds.append(round)
+        Round.createFromGame(self, word: word)
         
         playedWords.append(word)
         score += word.count
         lastError = nil
+        
+        refetch()
+    }
+    
+    func refetch() {
+        self.rounds = Round.findByGame(self)
     }
 }

--- a/WordRot/Models/Killswitch.swift
+++ b/WordRot/Models/Killswitch.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct Killswitch: Codable {
+    let badBuilds: [Int]
+    let minimumBuild: Int
+    
+    func verify(_ buildNumber: Int) -> Bool {
+        let goodBuild = !badBuilds.contains(buildNumber)
+        let atLeastMinimumBuild = buildNumber >= minimumBuild
+        
+        return goodBuild && atLeastMinimumBuild
+    }
+}

--- a/WordRot/Models/Loader.swift
+++ b/WordRot/Models/Loader.swift
@@ -3,7 +3,7 @@ import SQLite
 
 struct Loader {
     static func check(pass passCallback: () -> Void, fail failCallback: () -> Void) {
-        databaseStuff()
+        RottenDB.ensureDatabaseFile()
         killswitchStuff(pass: passCallback, fail: failCallback)
     }
     
@@ -24,19 +24,5 @@ struct Loader {
         
         let callback = killswitch.verify(buildNumber) ? passCallback : failCallback
         callback()
-    }
-    
-    static func databaseStuff() {
-        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-        let destinationPath = documentsUrl.appendingPathComponent("rotten.sqlite3").path
-        
-        guard !FileManager.default.fileExists(atPath: destinationPath) else { return }
-        
-        do {
-            let sourcePath = Bundle.main.path(forResource: "rotten.sqlite3", ofType: nil)!
-            try FileManager.default.copyItem(atPath: sourcePath, toPath: destinationPath)
-        } catch {
-            print("error during file copy: \(error)")
-        }
     }
 }

--- a/WordRot/Models/Loader.swift
+++ b/WordRot/Models/Loader.swift
@@ -1,7 +1,13 @@
 import Foundation
+import SQLite
 
 struct Loader {
     static func check(pass passCallback: () -> Void, fail failCallback: () -> Void) {
+        databaseStuff()
+        killswitchStuff(pass: passCallback, fail: failCallback)
+    }
+    
+    static func killswitchStuff(pass passCallback: () -> Void, fail failCallback: () -> Void) {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         
@@ -15,8 +21,22 @@ struct Loader {
         
         let buildVersion = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as! String
         let buildNumber = Int(buildVersion)!
-                
+        
         let callback = killswitch.verify(buildNumber) ? passCallback : failCallback
         callback()
+    }
+    
+    static func databaseStuff() {
+        let documentsUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let destinationPath = documentsUrl.appendingPathComponent("rotten.sqlite3").path
+        
+        guard !FileManager.default.fileExists(atPath: destinationPath) else { return }
+        
+        do {
+            let sourcePath = Bundle.main.path(forResource: "rotten.sqlite3", ofType: nil)!
+            try FileManager.default.copyItem(atPath: sourcePath, toPath: destinationPath)
+        } catch {
+            print("error during file copy: \(error)")
+        }
     }
 }

--- a/WordRot/Models/Loader.swift
+++ b/WordRot/Models/Loader.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct Loader {
+    static func check(pass passCallback: () -> Void, fail failCallback: () -> Void) {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        
+        let endpoint = "https://wordrot-production.herokuapp.com/api/v1/killswitch.json"
+        
+        guard
+            let killswitchUrl = URL(string: endpoint),
+            let data = try? Data(contentsOf: killswitchUrl),
+            let killswitch = try? decoder.decode(Killswitch.self, from: data)
+        else { return }
+        
+        let buildVersion = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as! String
+        let buildNumber = Int(buildVersion)!
+                
+        let callback = killswitch.verify(buildNumber) ? passCallback : failCallback
+        callback()
+    }
+}

--- a/WordRot/Models/Loader.swift
+++ b/WordRot/Models/Loader.swift
@@ -17,7 +17,7 @@ struct Loader {
             let killswitchUrl = URL(string: endpoint),
             let data = try? Data(contentsOf: killswitchUrl),
             let killswitch = try? decoder.decode(Killswitch.self, from: data)
-        else { return }
+        else { passCallback(); return }
         
         let buildVersion = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as! String
         let buildNumber = Int(buildVersion)!

--- a/WordRot/Models/RottenRecord.swift
+++ b/WordRot/Models/RottenRecord.swift
@@ -1,0 +1,19 @@
+import Foundation
+import SQLite
+
+class RottenRecord {
+    static let dateFormatter = ISO8601DateFormatter()
+    
+    static func asInt(_ binding: Binding) -> Int? {
+        return binding as? Int
+    }
+    
+    static func asString(_ binding: Binding) -> String? {
+        return binding as? String
+    }
+    
+    static func asDate(_ binding: Binding) -> Date? {
+        guard let stringDate = asString(binding) else { return nil }
+        return dateFormatter.date(from: stringDate)
+    }
+}

--- a/WordRot/Models/Round.swift
+++ b/WordRot/Models/Round.swift
@@ -1,11 +1,46 @@
 import Foundation
+import SQLite
 
-class Round {
+class Round: RottenRecord {
+    static let findByGameSql = "SELECT * FROM rounds WHERE game_id = ?;"
+    static let createSql = "INSERT INTO rounds(game_id, word, number) VALUES (?, ?, ?);"
+    
     let id: Int
+    let gameId: Int
+    let word: String
+    let number: Int
+    let createdAt: Date
+    let updatedAt: Date
+    
+    static func findByGame(_ game: Game) -> [Round] {
+        let rows = RottenDB.shared.selectRows(findByGameSql, [game.id])
+        let rounds = rows.compactMap() { Round(bindings: $0) }
         
-    init(gameId: Int, word: String, number: Int) {
-        let sql = "insert into rounds(game_id, word, number) values (\(gameId), '\(word)', \(number)) returning id;"
-        let id = try! RottenDB.sharedClient.scalar(sql) as! Int64
-        self.id = Int(id)
+        return rounds
+    }
+    
+    static func createFromGame(_ game: Game, word: String) {
+        let gameId = game.id
+        let nextNumber = game.playedWords.count + 1
+        
+        try! RottenDB.sharedClient.run(createSql, gameId, word, nextNumber)
+    }
+    
+    init?(bindings: [Binding]) {
+        guard
+            let id = Round.asInt(bindings[0]),
+            let gameId = Round.asInt(bindings[1]),
+            let word = Round.asString(bindings[2]),
+            let number = Round.asInt(bindings[3]),
+            let createdAt = Round.asDate(bindings[4]),
+            let updatedAt = Round.asDate(bindings[5])
+        else { return nil }
+        
+        self.id = id
+        self.gameId = gameId
+        self.word = word
+        self.number = number
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
     }
 }

--- a/WordRot/Models/Round.swift
+++ b/WordRot/Models/Round.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+class Round {
+    let id: Int
+        
+    init(gameId: Int, word: String, number: Int) {
+        let sql = "insert into rounds(game_id, word, number) values (\(gameId), '\(word)', \(number)) returning id;"
+        let id = try! RottenDB.sharedClient.scalar(sql) as! Int64
+        self.id = Int(id)
+    }
+}

--- a/WordRot/Screens/RootScreen.swift
+++ b/WordRot/Screens/RootScreen.swift
@@ -1,38 +1,5 @@
 import SwiftUI
 
-struct Loader {
-    static func check(pass passCallback: () -> Void, fail failCallback: () -> Void) {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        
-        let endpoint = "https://wordrot-production.herokuapp.com/api/v1/killswitch.json"
-        
-        guard
-            let killswitchUrl = URL(string: endpoint),
-            let data = try? Data(contentsOf: killswitchUrl),
-            let killswitch = try? decoder.decode(Killswitch.self, from: data)
-        else { return }
-        
-        let buildVersion = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as! String
-        let buildNumber = Int(buildVersion)!
-                
-        let callback = killswitch.verify(buildNumber) ? passCallback : failCallback
-        callback()
-    }
-}
-
-struct Killswitch: Codable {
-    let badBuilds: [Int]
-    let minimumBuild: Int
-    
-    func verify(_ buildNumber: Int) -> Bool {
-        let goodBuild = !badBuilds.contains(buildNumber)
-        let atLeastMinimumBuild = buildNumber >= minimumBuild
-        
-        return goodBuild && atLeastMinimumBuild
-    }
-}
-
 struct RootScreen: View {
     @State private var isLoading = true
     @State private var showPrompt = false

--- a/WordRot/Screens/ScoresScreen.swift
+++ b/WordRot/Screens/ScoresScreen.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+struct ScoresScreen: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    let gameCountSql = "SELECT COUNT(*) FROM games;"
+    let scoreSql = "SELECT SUM(LENGTH(word)) AS score FROM rounds GROUP BY game_id ORDER BY score DESC;"
+    
+    var scores: [String] {
+        let rows = RottenDB.shared.selectRows(scoreSql)
+        let points = rows.compactMap() { $0.first as? Int64 }
+        return points.map() { "\($0) points" }
+    }
+    
+    var summaryLine: String {
+        let gameCount = try! RottenDB.sharedClient.scalar(gameCountSql) as! Int64
+        return "\(gameCount) games played"
+    }
+    
+    var body: some View {
+        VStack {
+            HStack() {
+                Text("Top Scores")
+                    .font(Font.futura(30))
+                Spacer()
+                RottenButton("done", action: handleDonePress)
+            }
+            
+            Text(summaryLine)
+                .font(Font.futura(30))
+            
+            ForEach(scores, id: \.self) { score in
+                Text(score)
+                    .font(Font.futura(30))
+            }
+            
+            Spacer()
+        }
+        .padding(20)
+        .navigationBarHidden(true)
+    }
+    
+    func handleDonePress() {
+        dismiss()
+    }
+}
+
+struct ScoresScreen_Previews: PreviewProvider {
+    static var previews: some View {
+        ScoresScreen()
+            .preferredColorScheme(.dark)
+    }
+}

--- a/WordRot/Screens/TitleScreen.swift
+++ b/WordRot/Screens/TitleScreen.swift
@@ -4,7 +4,7 @@ struct TitleScreen: View {
     @ObservedObject var store: GameStore
     
     var body: some View {
-        let gameView = GameScreen(game: store.currentGame)
+        let gameScreen = GameScreen(game: store.currentGame)
         
         NavigationView {
             VStack {
@@ -14,7 +14,9 @@ struct TitleScreen: View {
                 Text("spell words, avoid rot")
                     .font(Font.futura(30))
                 Spacer()
-                RottenLink("start", destination: gameView)
+                RottenLink("start", destination: gameScreen)
+                Spacer().frame(height: 30)
+                RottenLink("scores", destination: ScoresScreen())
                 Spacer()
             }
         }


### PR DESCRIPTION
This PR adds a screen for users to see their top scores. I used this as an opportunity to lay down a bunch of foundational stuff:

* rename initial database to more general name
* copy initial database to app's documents folder so that it could persist data properly
* support database migrations
* create game/round models backed by database

So yeah a LOT of work for this simple screen:

<img width="564" alt="Screen Shot 2022-03-27 at 3 42 13 PM" src="https://user-images.githubusercontent.com/79799/160300273-af0cf779-a261-469f-9ce0-15697a223f88.png">

But the good news is that I think this sets me up really nicely to implement a bunch of missing functionality, namely that the board actually rots between rounds!