### PR TITLE
Setup circleci to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,17 @@
+version: 2.1
+
+jobs:
+  test:
+    macos:
+      xcode: 13.2.1
+    steps:
+      - checkout
+      - run:
+          name: Run Tests
+          command: ./bin/test
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Word Rot Game [![CircleCI][badge]][circle]
+
+This is the repo for Word Rot.
+
+[badge]: https://circleci.com/gh/verynicecode/wordrot-game.svg?style=svg
+[circle]: https://circleci.com/gh/verynicecode/wordrot-game


### PR DESCRIPTION
After noticing that CircleCI now allows macOS builds for free I have returned to this topic. I did a little bit of tinkering and was able to get the existing tests to run!

Closes #19 