### PR TITLE
Scroll lists that grow off screen

### DIFF
--- a/WordRot/Screens/RoundsScreen.swift
+++ b/WordRot/Screens/RoundsScreen.swift
@@ -14,11 +14,18 @@ struct RoundsScreen: View {
                 RottenButton("done", action: handleDonePress)
             }
             
-            ForEach(game.playedWords, id: \.self) { word in
-                Text(word)
-                    .font(Font.futura(20))
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    HStack() {
+                        Spacer()
+                    }
+                    
+                    ForEach(game.playedWords, id: \.self) { word in
+                        Text(word)
+                            .font(Font.futura(20))
+                    }
+                }
             }
-            
             Spacer()
         }
         .padding(20)

--- a/WordRot/Screens/ScoresScreen.swift
+++ b/WordRot/Screens/ScoresScreen.swift
@@ -29,9 +29,17 @@ struct ScoresScreen: View {
             Text(summaryLine)
                 .font(Font.futura(30))
             
-            ForEach(scores, id: \.self) { score in
-                Text(score)
-                    .font(Font.futura(30))
+            ScrollView {
+                VStack() {
+                    HStack() {
+                        Spacer()
+                    }
+                    
+                    ForEach(scores, id: \.self) { score in
+                        Text(score)
+                            .font(Font.futura(30))
+                    }
+                }
             }
             
             Spacer()

--- a/WordRot/Views/LetterTileView.swift
+++ b/WordRot/Views/LetterTileView.swift
@@ -9,7 +9,6 @@ let rotToOpacity = [
 ]
 
 struct LetterTileView: View {
-    @State private var animateGradient = false
     @ObservedObject var tile: Tile
     
     var opacity: CGFloat {


### PR DESCRIPTION
This PR just wraps a `ScrollView` around some lists of words and scores that were able to grow off screen. Take that!

BONUS: @pepopowitz discovered that I had an unused State property.